### PR TITLE
Cocoapods Support

### DIFF
--- a/ComposableArchitecture.podspec
+++ b/ComposableArchitecture.podspec
@@ -10,6 +10,7 @@ Point-Free’s The Composable Architecture uses Apple's Combine framework as the
   s.homepage         = 'https://github.com/dannyhertz/rxswift-composable-architecture'
   s.author           = { 'Danny Hertz' => 'me@dannyhertz.com' }
   s.source           = { :git => 'https://github.com/dannyhertz/rxswift-composable-architecture.git', :tag => s.version.to_s }
+  s.license          = { :type => 'MIT' }
 
   s.ios.deployment_target = '12.0'
   s.swift_version = '5.2'

--- a/ComposableArchitecture.podspec
+++ b/ComposableArchitecture.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name             = 'ComposableArchitecture'
+  s.version          = '0.8.0'
+  s.summary          = 'A RxSwift fork of The Composable Architecture.'
+
+  s.description      = <<-DESC
+Point-Free’s The Composable Architecture uses Apple's Combine framework as the basis of its Effect type. Unfortunately, Combine is only available on iOS 13 and macOS 10.15 and above. In order to be able to use it with earlier versions of the OSes, this fork has adapted The Composable Architecture to use RxSwift as the basis for the Effect type. Much of this work was also inspired by the wonderful ReactiveSwift port of this project as well.
+                       DESC
+
+  s.homepage         = 'https://github.com/dannyhertz/rxswift-composable-architecture'
+  s.author           = { 'Danny Hertz' => 'me@dannyhertz.com' }
+  s.source           = { :git => 'https://github.com/dannyhertz/rxswift-composable-architecture.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '12.0'
+  s.swift_version = '5.2'
+
+  s.source_files = 'Sources/ComposableArchitecture/**/*.swift'
+
+  s.dependency 'CasePaths'
+  s.dependency 'Overture'
+  s.dependency 'RxSwift', '~> 5.1.1'
+  s.dependency 'RxRelay'
+  s.xcconfig = { 'ENABLE_BITCODE' => 'NO' }
+end
+

--- a/README.md
+++ b/README.md
@@ -436,6 +436,13 @@ You can add ComposableArchitecture to an Xcode project by adding it as a package
       - If you have a single application target that needs access to the library, then add **ComposableArchitecture** directly to your application.
       - If you want to use this library from multiple targets you must create a shared framework that depends on **ComposableArchitecture** and then depend on that framework in all of your targets. For an example of this, check out the [Tic-Tac-Toe](./Examples/TicTacToe) demo application, which splits lots of features into modules and consumes the static library in this fashion using the **TicTacToeCommon** framework.
 
+### Cocoapods
+
+You will need to add this to your Podfile:
+```
+pod 'ComposableArchitecture', :git => 'git@github.com:dannyhertz/rxswift-composable-architecture.git'
+```
+
 ## Help
 
 If you want to discuss the Composable Architecture or have a question about how to use it to solve a particular problem, ask around on [its Swift forum](https://forums.swift.org/c/related-projects/swift-composable-architecture).


### PR DESCRIPTION
Adds cocoapods support for this repo. It's just one pod `ComposableArchitecture` and the TestStore and related code are added by default, under the `#if DEBUG` compiler flag.

#### TODO:
- [x] If/when this gets merged, I will probably need to go through and fixup some of the author and README to refer to Danny's fork
- [ ] Publish to Cocoapods? Benefits here is that then you don't need to specify git links. Not sure if the ReactiveSwift fork is already up there and if there will be a name collision. Perhaps `RxComposableArchitecture`?
    - We should do this after this gets merged
    - ~Will probably need to do the same to CasePaths. For now, that's still [under my fork](https://github.com/AdiAyyakad/swift-case-paths) but this might be worth pushing up so that installation is seamless for new users.~ Done